### PR TITLE
Add Express Middleware to set secure HTTP headers

### DIFF
--- a/server/start-server.ts
+++ b/server/start-server.ts
@@ -1,6 +1,7 @@
 import { promisify } from 'util';
 
 import express, { Request, Response } from 'express';
+import helmet from 'helmet';
 import logger from 'loglevel';
 
 import { NextHandlerType } from '.';
@@ -12,6 +13,8 @@ function startServer(handle: NextHandlerType, port: number) {
   const app = express();
 
   app.disable('x-powered-by');
+
+  app.use(helmet());
 
   app.use(express.json());
 

--- a/server/start-server.ts
+++ b/server/start-server.ts
@@ -11,6 +11,8 @@ import getRoutes from './routes';
 function startServer(handle: NextHandlerType, port: number) {
   const app = express();
 
+  app.disable('x-powered-by');
+
   app.use(express.json());
 
   app.use('/api', getRoutes());


### PR DESCRIPTION
Note: 

**If** in case **client-side cache has bugs in the future**, pls **look into Helmet's `noCache` option** (sets Cache-Control, Pragma headers to disable client-side caching).